### PR TITLE
Rename bases and cernlib to prevent conflicts with cascade

### DIFF
--- a/rapgap-3.303/bases51/Makefile.am
+++ b/rapgap-3.303/bases51/Makefile.am
@@ -5,8 +5,8 @@
 # AM_FFLAGS = -I$(top_srcdir)/include -fno-automatic -finit-local-zero -fno-backslash -fno-globals -ff90 -fpic
 AM_FFLAGS = $(MYFFLAGS)
 
-lib_LTLIBRARIES = libbases.la
-libbases_la_SOURCES = bases.f  bschck.f  bsgetw.f  bsintg.f  bsputw.f \
+lib_LTLIBRARIES = librapgapbases.la
+librapgapbases_la_SOURCES = bases.f  bschck.f  bsgetw.f  bsintg.f  bsputw.f \
                      bswrit.f drnset.f  shplot.f  sphist.f  xhfill.f \
                      xhscle.f bhinit.f  bsdate.f  bsgrid.f  bslist.f \
                      bsread.f dhfill.f  Makefile  shrset.f  spinfo.f \

--- a/rapgap-3.303/misc/Makefile.am
+++ b/rapgap-3.303/misc/Makefile.am
@@ -4,8 +4,8 @@
 
 AM_FFLAGS = $(MYFFLAGS)
 
-lib_LTLIBRARIES = libmycern.la
-libmycern_la_SOURCES = abend.F  besi0.F  expint.F  ranlux.F  rnpssn.F  \
+lib_LTLIBRARIES = librapgapmycern.la
+librapgapmycern_la_SOURCES = abend.F  besi0.F  expint.F  ranlux.F  rnpssn.F  \
                        ucopy.F  vzero.F dgauss.F rnormx.F \
                        datime.F timex.F  timest.F timed.F fint.F \
                        rgquad.F d107r1.F dgquad.F d107d1.F divdif.F \

--- a/rapgap-3.303/src/Makefile.am
+++ b/rapgap-3.303/src/Makefile.am
@@ -163,8 +163,8 @@ librapgap33_la_SOURCES = \
 
 #		rapgap/analys.F  rapgap/frag.F 
 
-LDADD = ./librapgap33.la ../bases51/libbases.la \
-        $(HEPMCLIB) $(HEPMC3LIB)  $(HEPMC3LIBROOTIO)  $(RIVETLIB) $(ARIADNELIB) $(PYTHIALIB) $(ARIADNELIB) $(PDFLIB) ../misc/libmycern.la -lstdc++ -lm
+LDADD = ./librapgap33.la ../bases51/librapgapbases.la \
+        $(HEPMCLIB) $(HEPMC3LIB)  $(HEPMC3LIBROOTIO)  $(RIVETLIB) $(ARIADNELIB) $(PYTHIALIB) $(ARIADNELIB) $(PDFLIB) ../misc/librapgapmycern.la -lstdc++ -lm
 
 
 #all:


### PR DESCRIPTION
Rename bases and cernlib to prevent conflicts with cascade